### PR TITLE
feat: add podmonitor resource

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudflared
 description: Helm chart to deploy Cloudflare Tunnel
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: 2021.12.4

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 2000
+              prtoocol: TCP
           args:
             - tunnel
             - --config

--- a/charts/cloudflared/templates/podmonitor.yaml
+++ b/charts/cloudflared/templates/podmonitor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.podMonitor.enabled .Values.podMonitor.metricsEndpoints }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "cloudflared.fullname" . }}
+  labels:
+    {{- include "cloudflared.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.podMonitor.extraLabels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cloudflared.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  {{- toYaml .Values.podMonitor.metricsEndpoints | nindent 2 }}
+{{- end }}

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -53,3 +53,14 @@ config:
   - hostname: hello.example.com
     service: http://hello.mynamespace:8000
   - service: http_status:404
+
+podMonitor:
+  enabled: false
+
+  metricsEndpoints: {}
+  # - port: http
+  #   interval: 15s
+
+  # additional labels for the ServiceMonitor
+  extraLabels: {}
+  #  release: kube-prometheus-stack


### PR DESCRIPTION
This PR would add the options to enable the PodMonitor for the cloudflared pods.

Values set example:
```yaml
podMonitor:
  enabled: true
  metricsEndpoints:
  - port: http

  # additional labels for the PodMonitor
  extraLabels:
    release: kube-prometheus-stack
```

Generated PodMonitor manifest:
```
# Source: cloudflared/templates/podmonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: RELEASE-NAME-cloudflared
  labels:
    helm.sh/chart: cloudflared-0.2.2
    app.kubernetes.io/name: cloudflared
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "2021.12.4"
    app.kubernetes.io/managed-by: Helm
    release: "kube-prometheus-stack"
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: cloudflared
      app.kubernetes.io/instance: RELEASE-NAME
  podMetricsEndpoints:
  - port: http
```